### PR TITLE
wdte: Make Modules Act like Functions

### DIFF
--- a/translate.go
+++ b/translate.go
@@ -142,16 +142,26 @@ func (m *Module) fromFunc(f *ast.NTerm, scope map[ID]int) Func {
 
 	sub := m.fromSubfunc(f.Children()[1].(*ast.NTerm))
 	if sub != "" {
-		return &External{
-			Module: m,
-			Import: &Local{
+		var im Func
+
+		arg, ok := scope[id]
+		switch ok {
+		case true:
+			im = Arg(arg)
+		case false:
+			im = &Local{
 				Module: m,
 				Func:   id,
 
 				Line: tok.Line,
 				Col:  tok.Col,
-			},
-			Func: sub,
+			}
+		}
+
+		return &External{
+			Module: m,
+			Import: im,
+			Func:   sub,
 
 			// These are off slightly. They should be set from the token
 			// that m.fromSubfunc() uses.

--- a/translate.go
+++ b/translate.go
@@ -16,9 +16,6 @@ func (m *Module) fromScript(script *ast.NTerm, im Importer) (*Module, error) {
 }
 
 func (m *Module) fromDecls(decls []ast.Node, im Importer) (*Module, error) {
-	if m.Imports == nil {
-		m.Imports = make(map[ID]*Module)
-	}
 	if m.Funcs == nil {
 		m.Funcs = make(map[ID]Func)
 	}
@@ -30,7 +27,7 @@ func (m *Module) fromDecls(decls []ast.Node, im Importer) (*Module, error) {
 			if err != nil {
 				return nil, err
 			}
-			m.Imports[id] = sub
+			m.Funcs[id] = sub
 
 		case "funcdecl":
 			def := m.fromFuncDecl(d.Children()[0].(*ast.NTerm))
@@ -147,9 +144,17 @@ func (m *Module) fromFunc(f *ast.NTerm, scope map[ID]int) Func {
 	if sub != "" {
 		return &External{
 			Module: m,
-			Import: id,
-			Func:   sub,
+			Import: &Local{
+				Module: m,
+				Func:   id,
 
+				Line: tok.Line,
+				Col:  tok.Col,
+			},
+			Func: sub,
+
+			// These are off slightly. They should be set from the token
+			// that m.fromSubfunc() uses.
 			Line: tok.Line,
 			Col:  tok.Col,
 		}

--- a/wdte_test.go
+++ b/wdte_test.go
@@ -146,6 +146,20 @@ func TestBasics(t *testing.T) {
 			args:   []wdte.Func{wdte.Number(38)},
 			ret:    wdte.Number(39088169),
 		},
+		{
+			name:   "PassModule",
+			script: `'somemodule' => m; test im => im.num; main => test m;`,
+			im: wdte.ImportFunc(func(from string) (*wdte.Module, error) {
+				return &wdte.Module{
+					Funcs: map[wdte.ID]wdte.Func{
+						"num": wdte.GoFunc(func(frame wdte.Frame, args ...wdte.Func) wdte.Func {
+							return wdte.Number(3)
+						}),
+					},
+				}, nil
+			}),
+			ret: wdte.Number(3),
+		},
 		//{
 		//	name:   "Frame",
 		//	script: `'frame' => frame; test => frame.get; main => test;`,


### PR DESCRIPTION
Part of #14.

This is a potentially breaking change, as it will break any code which has functions with arguments that have the same ID as an import.