### PR TITLE
multiple: Don't overwrite elements of `args` in function calls.

### DIFF
--- a/std/strings/format.go
+++ b/std/strings/format.go
@@ -44,13 +44,14 @@ func Format(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 		})
 	}
 
-	for i := range args {
-		args[i] = args[i].Call(frame)
+	next := make([]wdte.Func, 0, len(args))
+	for _, arg := range args {
+		next = append(next, arg.Call(frame))
 	}
 
 	var i int
 	var out bytes.Buffer
-	s := strings.NewReader(string(args[0].(wdte.String)))
+	s := strings.NewReader(string(next[0].(wdte.String)))
 	for {
 		r, _, err := s.ReadRune()
 		if err != nil {
@@ -98,7 +99,7 @@ func Format(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 		}
 
 		i++
-		out.WriteString(flags.Format(args[i]))
+		out.WriteString(flags.Format(next[i]))
 	}
 }
 

--- a/wdte.go
+++ b/wdte.go
@@ -602,13 +602,13 @@ func (m *Memo) Call(frame Frame, args ...Func) Func { // nolint
 		check = append(check, arg.Call(frame))
 	}
 
-	cached, ok := m.cache.Get(args)
+	cached, ok := m.cache.Get(check)
 	if ok {
 		return cached
 	}
 
-	r := m.Func.Call(frame, args...)
-	m.cache.Set(args, r)
+	r := m.Func.Call(frame, check...)
+	m.cache.Set(check, r)
 	return r
 }
 

--- a/wdte_test.go
+++ b/wdte_test.go
@@ -129,8 +129,6 @@ func TestBasics(t *testing.T) {
 			ret:    wdte.Number(144),
 		},
 		{
-			// BUG: Due to the scope overhaul, memoization doesn't work.
-			disabled: true,
 			// Wonder why memo exists? Try removing the keyword from this
 			// test script and see what happens.
 			name:   "Fib/Memo",


### PR DESCRIPTION
Turns out it breaks things. Like memoization.