### PR TITLE
wdte: Fix lambda recursion.

### DIFF
--- a/wdte.go
+++ b/wdte.go
@@ -340,14 +340,14 @@ type DeclFunc struct {
 
 func (f DeclFunc) Call(frame Frame, args ...Func) Func { // nolint
 	vars := make(map[ID]Func, len(f.Args)+len(f.Stored))
+	for id, arg := range f.Stored {
+		vars[id] = arg
+	}
 	for i, arg := range args {
 		vars[f.Args[i]] = &ScopedFunc{
 			Func:  arg,
 			Scope: frame.Scope(),
 		}
-	}
-	for id, arg := range f.Stored {
-		vars[id] = arg
 	}
 
 	if len(args) < len(f.Args) {
@@ -683,18 +683,15 @@ type Lambda struct {
 
 func (lambda *Lambda) Call(frame Frame, args ...Func) Func { // nolint
 	vars := make(map[ID]Func, len(lambda.Args)+len(lambda.Stored))
-	vars[lambda.ID] = &ScopedFunc{
-		Func:  lambda,
-		Scope: frame.Scope(),
+	vars[lambda.ID] = lambda
+	for id, arg := range lambda.Stored {
+		vars[id] = arg
 	}
 	for i, arg := range args {
 		vars[lambda.Args[i]] = &ScopedFunc{
 			Func:  arg,
 			Scope: frame.Scope(),
 		}
-	}
-	for id, arg := range lambda.Stored {
-		vars[id] = arg
 	}
 
 	if len(args) < len(lambda.Args) {

--- a/wdte.go
+++ b/wdte.go
@@ -440,10 +440,12 @@ func (f IgnoredChain) Call(frame Frame, args ...Func) Func { // nolint
 	return f.Chain.Call(frame, args[0])
 }
 
+// An EndChain is a no-op that just returns its own first argument.
+// This is used as the last element of a chain.
 type EndChain struct {
 }
 
-func (f EndChain) Call(frame Frame, args ...Func) Func {
+func (f EndChain) Call(frame Frame, args ...Func) Func { // nolint
 	return args[0]
 }
 
@@ -586,9 +588,11 @@ func (s Switch) Call(frame Frame, args ...Func) Func { // nolint
 	return nil
 }
 
+// A Var represents a local variable. When called, it looks itself up
+// in the frame that it's given and calls whatever it finds.
 type Var ID
 
-func (v Var) Call(frame Frame, args ...Func) Func {
+func (v Var) Call(frame Frame, args ...Func) Func { // nolint
 	return frame.Scope().Get(ID(v)).Call(frame, args...)
 }
 

--- a/wdte_test.go
+++ b/wdte_test.go
@@ -167,10 +167,19 @@ func TestBasics(t *testing.T) {
 			ret:    wdte.Number(6),
 		},
 		{
+			name:   "Lambda/Fib",
+			script: `test a => a 10; main => test (@ t n => switch n { <= 1 => n; default => + (t (- n 2)) (t (- n 1)); };);`,
+			ret:    wdte.Number(55),
+		},
+		{
+			// BUG: This doesn't work because the second level is not
+			// memoized. This may require reversing memoization again so
+			// that the inner expression is wrapped in a Memo, instead of
+			// wrapping the whole thing in it.
 			disabled: true,
-			name:     "Lambda/Fib",
-			script:   `test a => a 5; main => test (@ t n => switch n { <= 1 => n; default => + (t (- n 2)) (t (- n 1)); };);`,
-			ret:      wdte.Number(8),
+			name:     "Lambda/Fib/Memo",
+			script:   `test a => a 38; main => test (@ memo t n => switch n { <= 1 => n; default => + (t (- n 2)) (t (- n 1)); };);`,
+			ret:      wdte.Number(39088169),
 		},
 	})
 }


### PR DESCRIPTION
Memoization doesn't work, but it actually doesn't quite work for 'normal' functions. Might need to tweak a few things to get it working right.

Closes #35.