### PR TITLE
stream: Change `flatMap` to use streams instead of arrays.

### DIFF
--- a/std/stream/start.go
+++ b/std/stream/start.go
@@ -16,7 +16,16 @@ func New(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	}
 
 	frame = frame.WithID("new")
-	return &array{a: args}
+
+	var a array
+	for _, arg := range args {
+		a.a = append(a.a, &wdte.ScopedFunc{
+			Func:  arg,
+			Scope: frame.Scope(),
+		})
+	}
+
+	return &a
 }
 
 func (a *array) Call(frame wdte.Frame, args ...wdte.Func) wdte.Func {

--- a/wdte.go
+++ b/wdte.go
@@ -261,7 +261,7 @@ func (s *Scope) get(id ID) Func {
 		return f
 	}
 
-	return s.p.Get(id)
+	return s.p.get(id)
 }
 
 // Get returns value of the variable with the given id. If the

--- a/wdte_test.go
+++ b/wdte_test.go
@@ -268,7 +268,7 @@ func TestMath(t *testing.T) {
 func TestStream(t *testing.T) {
 	runTests(t, []test{
 		{
-			name:   "New/Args",
+			name:   "New",
 			script: `'stream' => s; main a b c => s.new a b c -> s.collect;`,
 			args:   []wdte.Func{wdte.Number(3), wdte.Number(6), wdte.Number(9)},
 			ret:    wdte.Array{wdte.Number(3), wdte.Number(6), wdte.Number(9)},
@@ -296,7 +296,7 @@ func TestStream(t *testing.T) {
 		},
 		{
 			name:   "FlatMap",
-			script: `'stream' => s; test a => [a; + a 1]; main => s.range 3 -> s.flatMap test -> s.collect;`,
+			script: `'stream' => s; test a => s.new a (+ a 1); main => s.range 3 -> s.flatMap test -> s.collect;`,
 			ret: wdte.Array{
 				wdte.Number(0),
 				wdte.Number(1),


### PR DESCRIPTION
Cleaner and, probably, more memory efficient.