### PR TITLE
std: Invert imports.

### DIFF
--- a/std/arrays/arrays.go
+++ b/std/arrays/arrays.go
@@ -1,6 +1,9 @@
 package arrays
 
-import "github.com/DeedleFake/wdte"
+import (
+	"github.com/DeedleFake/wdte"
+	"github.com/DeedleFake/wdte/std"
+)
 
 // At returns the element at the index of the first argument specified
 // by the second argument. In other words,
@@ -76,4 +79,8 @@ func Module() *wdte.Module {
 			"stream": wdte.GoFunc(Stream),
 		},
 	}
+}
+
+func init() {
+	std.Register("arrays", Module())
 }

--- a/std/import.go
+++ b/std/import.go
@@ -1,0 +1,28 @@
+package std
+
+import (
+	"fmt"
+
+	"github.com/DeedleFake/wdte"
+)
+
+var (
+	// Import provides a simple importer that imports registered
+	// modules.
+	Import = wdte.ImportFunc(stdImporter)
+
+	modules = make(map[string]*wdte.Module)
+)
+
+func stdImporter(from string) (*wdte.Module, error) {
+	if m, ok := modules[from]; ok {
+		return m, nil
+	}
+
+	return nil, fmt.Errorf("Unknown import: %q", from)
+}
+
+// Register registers a module for importing by Import.
+func Register(name string, module *wdte.Module) {
+	modules[name] = module
+}

--- a/std/io/file/file.go
+++ b/std/io/file/file.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/DeedleFake/wdte"
+	"github.com/DeedleFake/wdte/std"
 )
 
 // File wraps an os.File, allowing it to be used as a WDTE function.
@@ -75,4 +76,8 @@ func Module() *wdte.Module {
 			"append": wdte.GoFunc(Append),
 		},
 	}
+}
+
+func init() {
+	std.Register("io/file", Module())
 }

--- a/std/io/io.go
+++ b/std/io/io.go
@@ -14,6 +14,27 @@ import (
 	"github.com/DeedleFake/wdte/std"
 )
 
+// These variables are what are returned by the cooresponding
+// functions in this package. If a client wants to globally redirect
+// input or output, them may simply change these variables.
+var (
+	Stdin  io.Reader = os.Stdin
+	Stdout io.Writer = os.Stdout
+	Stderr io.Writer = os.Stderr
+)
+
+func stdin(frame wdte.Frame, args ...wdte.Func) wdte.Func {
+	return Reader{Stdin}
+}
+
+func stdout(frame wdte.Frame, args ...wdte.Func) wdte.Func {
+	return Writer{Stderr}
+}
+
+func stderr(frame wdte.Frame, args ...wdte.Func) wdte.Func {
+	return Writer{Stderr}
+}
+
 type reader interface {
 	wdte.Func
 	io.Reader
@@ -441,9 +462,9 @@ func Writeln(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 func Module() *wdte.Module {
 	return &wdte.Module{
 		Funcs: map[wdte.ID]wdte.Func{
-			"stdin":  Reader{Reader: os.Stdin},
-			"stdout": Writer{Writer: os.Stdout},
-			"stderr": Writer{Writer: os.Stderr},
+			"stdin":  wdte.GoFunc(stdin),
+			"stdout": wdte.GoFunc(stdout),
+			"stderr": wdte.GoFunc(stderr),
 
 			"seek":  wdte.GoFunc(Seek),
 			"close": wdte.GoFunc(Close),

--- a/std/io/io.go
+++ b/std/io/io.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/DeedleFake/wdte"
+	"github.com/DeedleFake/wdte/std"
 )
 
 type reader interface {
@@ -461,4 +462,8 @@ func Module() *wdte.Module {
 			"writeln": wdte.GoFunc(Writeln),
 		},
 	}
+}
+
+func init() {
+	std.Register("io", Module())
 }

--- a/std/math/math.go
+++ b/std/math/math.go
@@ -6,6 +6,7 @@ import (
 	"math"
 
 	"github.com/DeedleFake/wdte"
+	"github.com/DeedleFake/wdte/std"
 )
 
 // Pi ignores its arguments and returns π as a wdte.Number.
@@ -103,4 +104,8 @@ func Module() *wdte.Module {
 			"abs":   wdte.GoFunc(Abs),
 		},
 	}
+}
+
+func init() {
+	std.Register("math", Module())
 }

--- a/std/std.go
+++ b/std/std.go
@@ -5,12 +5,6 @@ import (
 	"math"
 
 	"github.com/DeedleFake/wdte"
-	"github.com/DeedleFake/wdte/std/arrays"
-	stdio "github.com/DeedleFake/wdte/std/io"
-	"github.com/DeedleFake/wdte/std/io/file"
-	stdmath "github.com/DeedleFake/wdte/std/math"
-	"github.com/DeedleFake/wdte/std/stream"
-	"github.com/DeedleFake/wdte/std/strings"
 )
 
 func save(f wdte.Func, saved ...wdte.Func) wdte.Func {
@@ -419,30 +413,4 @@ func Module() *wdte.Module {
 			"!":     wdte.GoFunc(Not),
 		},
 	}
-}
-
-// Import provides a simple importer that imports standard library
-// modules.
-var Import = wdte.ImportFunc(stdImporter)
-
-func stdImporter(from string) (*wdte.Module, error) {
-	switch from {
-	case "stream":
-		return stream.Module(), nil
-
-	case "math":
-		return stdmath.Module(), nil
-
-	case "io":
-		return stdio.Module(), nil
-	case "io/file":
-		return file.Module(), nil
-
-	case "strings":
-		return strings.Module(), nil
-	case "arrays":
-		return arrays.Module(), nil
-	}
-
-	return nil, fmt.Errorf("Unknown import: %q", from)
 }

--- a/std/stream/stream.go
+++ b/std/stream/stream.go
@@ -2,7 +2,10 @@
 // data.
 package stream
 
-import "github.com/DeedleFake/wdte"
+import (
+	"github.com/DeedleFake/wdte"
+	"github.com/DeedleFake/wdte/std"
+)
 
 // A Stream is a type of function that can yield successive values.
 type Stream interface {
@@ -49,4 +52,8 @@ func Module() *wdte.Module {
 			"all": wdte.GoFunc(All),
 		},
 	}
+}
+
+func init() {
+	std.Register("stream", Module())
 }

--- a/std/strings/strings.go
+++ b/std/strings/strings.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/DeedleFake/wdte"
+	"github.com/DeedleFake/wdte/std"
 )
 
 // Contains returns true if the second argument is a substring of the
@@ -167,4 +168,8 @@ func Module() *wdte.Module {
 			"format": wdte.GoFunc(Format),
 		},
 	}
+}
+
+func init() {
+	std.Register("strings", Module())
 }

--- a/wdte_test.go
+++ b/wdte_test.go
@@ -9,7 +9,11 @@ import (
 
 	"github.com/DeedleFake/wdte"
 	"github.com/DeedleFake/wdte/std"
+	_ "github.com/DeedleFake/wdte/std/arrays"
 	"github.com/DeedleFake/wdte/std/io"
+	_ "github.com/DeedleFake/wdte/std/math"
+	_ "github.com/DeedleFake/wdte/std/stream"
+	_ "github.com/DeedleFake/wdte/std/strings"
 )
 
 type test struct {


### PR DESCRIPTION
Inverts imports to work the way the `image` package does in the Go standard library. Standard library imports now register themselves with `std.Import` in an `init()` function, meaning that you can selectively import parts of the standard library more easily. For example, if you want to import just the `io` package, just import the following in Go code:

```go
"github.com/DeedleFake/wdte/std"
_ "github.com/DeedleFake/wdte/std/io"
```

Then use `std.Import` as usual.