### PR TITLE
wdte: Call the last element of a compound again with arguments if any are given.

### DIFF
--- a/wdte.go
+++ b/wdte.go
@@ -514,6 +514,10 @@ func (c Compound) Collect(frame Frame, args ...Func) (*Scope, Func) {
 		last = let.Call(frame)
 	}
 
+	if len(args) > 0 {
+		last = last.Call(frame, args...)
+	}
+
 	return frame.Scope(), last
 }
 

--- a/wdte_test.go
+++ b/wdte_test.go
@@ -152,6 +152,11 @@ func TestBasics(t *testing.T) {
 			ret:    wdte.Number(8),
 		},
 		{
+			name:   "Simple/Compound/Args",
+			script: `let test x y => + x y; (test 3) 5;`,
+			ret:    wdte.Number(8),
+		},
+		{
 			name:   "Simple/Memo",
 			script: `let memo test n => + n 3; let main => (test 5; test 5); main;`,
 			ret:    wdte.Number(8),


### PR DESCRIPTION
Closes #64.