### PR TITLE
wdte: Don't wrap argumentless `let`s in Lambdas.

### DIFF
--- a/translate.go
+++ b/translate.go
@@ -90,13 +90,22 @@ func (m *translator) fromLetExpr(expr *ast.NTerm) Func {
 		}
 	}
 
-	return &Let{
-		ID: id,
-		Expr: &Lambda{
+	var right Func
+	switch len(args) {
+	case 0:
+		right = inner
+
+	default:
+		right = &Lambda{
 			ID:   id,
 			Expr: inner,
 			Args: args,
-		},
+		}
+	}
+
+	return &Let{
+		ID:   id,
+		Expr: right,
 	}
 }
 

--- a/wdte_test.go
+++ b/wdte_test.go
@@ -275,6 +275,11 @@ func TestBasics(t *testing.T) {
 			script: `let x => 3;`,
 			ret:    wdte.Number(3),
 		},
+		{
+			name:   "Let/NoArgs",
+			script: `let x => 3; let x => + x 5; x;`,
+			ret:    wdte.Number(8),
+		},
 	})
 }
 


### PR DESCRIPTION
Closes #63.