### PR TITLE
multiple: Rework basically all the standard library documentation plus a few other tweaks.

### DIFF
--- a/std/arrays/arrays.go
+++ b/std/arrays/arrays.go
@@ -11,7 +11,11 @@ type streamer struct {
 	i int
 }
 
-// Stream returns a stream that iterates over a given array.
+// Stream is a WDTE function with the following signature:
+//
+//    stream a
+//
+// Returns a stream.Stream that iterates over the array a.
 func Stream(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	frame = frame.Sub("stream")
 
@@ -23,11 +27,11 @@ func Stream(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return &streamer{a: args[0].Call(frame).(wdte.Array)}
 }
 
-func (a *streamer) Call(frame wdte.Frame, args ...wdte.Func) wdte.Func {
+func (a *streamer) Call(frame wdte.Frame, args ...wdte.Func) wdte.Func { // nolint
 	return a
 }
 
-func (a *streamer) Next(frame wdte.Frame) (wdte.Func, bool) {
+func (a *streamer) Next(frame wdte.Frame) (wdte.Func, bool) { // nolint
 	if a.i >= len(a.a) {
 		return nil, false
 	}
@@ -37,14 +41,11 @@ func (a *streamer) Next(frame wdte.Frame) (wdte.Func, bool) {
 	return r, true
 }
 
-// S returns a top-level scope containing the various functions in
-// this package.
-func S() *wdte.Scope {
-	return wdte.S().Map(map[wdte.ID]wdte.Func{
-		"stream": wdte.GoFunc(Stream),
-	})
-}
+// Scope is a scope containing the functions in this package.
+var Scope = wdte.S().Map(map[wdte.ID]wdte.Func{
+	"stream": wdte.GoFunc(Stream),
+})
 
 func init() {
-	std.Register("arrays", S())
+	std.Register("arrays", Scope)
 }

--- a/std/io/file/file.go
+++ b/std/io/file/file.go
@@ -17,7 +17,11 @@ func (f File) Call(frame wdte.Frame, args ...wdte.Func) wdte.Func { // nolint
 	return f
 }
 
-// Open opens a file and returns it as a reader.
+// Open is a WDTE function with the following signature:
+//
+//    open path
+//
+// Opens the file at path and returns it.
 func Open(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	frame = frame.Sub("open")
 
@@ -33,8 +37,12 @@ func Open(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return File{File: file}
 }
 
-// Create creates a file, truncating it if it exists, and returns it
-// as a writer.
+// Create is a WDTE function with the following signature:
+//
+//    create path
+//
+// Creates the file at path, truncating it if it already exists, and
+// returns it.
 func Create(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	frame = frame.Sub("create")
 
@@ -50,8 +58,12 @@ func Create(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return File{File: file}
 }
 
-// Append opens a file for appending as a writer. If it doesn't exist
-// already, it is created.
+// Append is a WDTE function with the following signature:
+//
+//    append path
+//
+// Opens the file at path for appending, creating it if it doesn't
+// already exist, and returns it.
 func Append(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	frame = frame.Sub("append")
 
@@ -67,14 +79,12 @@ func Append(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return File{File: file}
 }
 
-// S returns a scope containing the functions in this package.
-func S() *wdte.Scope {
-	return wdte.S().Map(map[wdte.ID]wdte.Func{
-		"open":   wdte.GoFunc(Open),
-		"create": wdte.GoFunc(Create),
-		"append": wdte.GoFunc(Append),
-	})
-}
+// Scope is a scope containing the functions in this package.
+var Scope = wdte.S().Map(map[wdte.ID]wdte.Func{
+	"open":   wdte.GoFunc(Open),
+	"create": wdte.GoFunc(Create),
+	"append": wdte.GoFunc(Append),
+})
 
 func init() {
 	std.Register("io/file", S())

--- a/std/io/file/file.go
+++ b/std/io/file/file.go
@@ -87,5 +87,5 @@ var Scope = wdte.S().Map(map[wdte.ID]wdte.Func{
 })
 
 func init() {
-	std.Register("io/file", S())
+	std.Register("io/file", Scope)
 }

--- a/std/math/math.go
+++ b/std/math/math.go
@@ -9,12 +9,19 @@ import (
 	"github.com/DeedleFake/wdte/std"
 )
 
-// Pi ignores its arguments and returns π as a wdte.Number.
-func Pi(frame wdte.Frame, args ...wdte.Func) wdte.Func {
-	return wdte.Number(math.Pi)
-}
+// A number of useful constants. To see the IDs under which they are
+// exported, see Scope.
+const (
+	E     wdte.Number = math.E
+	Pi    wdte.Number = math.Pi
+	Sqrt2 wdte.Number = math.Sqrt2
+)
 
-// Sin returns sin(args[0]).
+// Sin is a WDTE function with the following signature:
+//
+//    sin n
+//
+// Returns the sine of n.
 func Sin(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) == 0 {
 		return wdte.GoFunc(Sin)
@@ -26,7 +33,11 @@ func Sin(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return wdte.Number(math.Sin(float64(a)))
 }
 
-// Cos returns cos(args[0]).
+// Cos is a WDTE function with the following signature:
+//
+//    cos n
+//
+// Returns the cosine of n.
 func Cos(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) == 0 {
 		return wdte.GoFunc(Cos)
@@ -38,7 +49,11 @@ func Cos(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return wdte.Number(math.Cos(float64(a)))
 }
 
-// Tan returns tan(args[0]).
+// Tan is a WDTE function with the following signature:
+//
+//    tan n
+//
+// Returns the tangent of n.
 func Tan(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) == 0 {
 		return wdte.GoFunc(Tan)
@@ -50,7 +65,11 @@ func Tan(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return wdte.Number(math.Tan(float64(a)))
 }
 
-// Floor returns ⌊args[0]⌋.
+// Floor is a WDTE function with the following signature:
+//
+//    floor n
+//
+// Returns ⌊n⌋.
 func Floor(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) == 0 {
 		return wdte.GoFunc(Floor)
@@ -62,7 +81,11 @@ func Floor(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return wdte.Number(math.Floor(float64(a)))
 }
 
-// Ceil returns ⌈args[0]⌉.
+// Ceil is a WDTE function with the following signature:
+//
+//    ceil n
+//
+// Returns ⌈n⌉.
 func Ceil(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) == 0 {
 		return wdte.GoFunc(Ceil)
@@ -74,7 +97,11 @@ func Ceil(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return wdte.Number(math.Ceil(float64(a)))
 }
 
-// Abs returns |args[0]|.
+// Abs is a WDTE function with the following signature:
+//
+//    abs n
+//
+// Returns |n|.
 func Abs(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) == 0 {
 		return wdte.GoFunc(Abs)
@@ -86,21 +113,21 @@ func Abs(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return wdte.Number(math.Abs(float64(a)))
 }
 
-// S returns a scope containing the various functions in this package.
-func S() *wdte.Scope {
-	return wdte.S().Map(map[wdte.ID]wdte.Func{
-		"pi": wdte.GoFunc(Pi),
+// Scope is a scope that contains the functions in this package.
+var Scope = wdte.S().Map(map[wdte.ID]wdte.Func{
+	"e":     E,
+	"pi":    Pi,
+	"sqrt2": Sqrt2,
 
-		"sin": wdte.GoFunc(Sin),
-		"cos": wdte.GoFunc(Cos),
-		"tan": wdte.GoFunc(Tan),
+	"sin": wdte.GoFunc(Sin),
+	"cos": wdte.GoFunc(Cos),
+	"tan": wdte.GoFunc(Tan),
 
-		"floor": wdte.GoFunc(Floor),
-		"ceil":  wdte.GoFunc(Ceil),
-		"abs":   wdte.GoFunc(Abs),
-	})
-}
+	"floor": wdte.GoFunc(Floor),
+	"ceil":  wdte.GoFunc(Ceil),
+	"abs":   wdte.GoFunc(Abs),
+})
 
 func init() {
-	std.Register("math", S())
+	std.Register("math", Scope)
 }

--- a/std/std.go
+++ b/std/std.go
@@ -13,9 +13,12 @@ func save(f wdte.Func, saved ...wdte.Func) wdte.Func {
 	})
 }
 
-// Add returns the sum of its arguments. If called with only 1
-// argument, it returns a function which adds arguments given to that
-// one argument.
+// Add is a WDTE function with the following signatures:
+//
+//    + a ...
+//    (+ a) ...
+//
+// Returns the sum of a and the rest of its arguments.
 func Add(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) <= 1 {
 		return save(wdte.GoFunc(Add), args...)
@@ -34,9 +37,12 @@ func Add(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return sum
 }
 
-// Sub returns args[0] - args[1]. If called with only 1 argument, it
-// returns a function which returns the argument given minus that
-// argument.
+// Sub is a WDTE with the following signatures:
+//
+//    - a b
+//    (- b) a
+//
+// Returns a minus b.
 func Sub(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) <= 1 {
 		return save(wdte.GoFunc(Sub), args...)
@@ -57,9 +63,12 @@ func Sub(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return a1.(wdte.Number) - a2.(wdte.Number)
 }
 
-// Mult returns the product of its arguments. If called with only 1
-// argument, it returns a function that multiplies that argument by
-// its own arguments.
+// Mult is a WDTE function with the following signatures:
+//
+//    * a ...
+//    (* a) ...
+//
+// Returns the product of a and its other arguments.
 func Mult(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) <= 1 {
 		return save(wdte.GoFunc(Mult), args...)
@@ -78,9 +87,12 @@ func Mult(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return p
 }
 
-// Div returns args[0] / args[1]. If called with only 1 argument, it
-// returns a function which divides the original argument by its own
-// argument.
+// Div is a WDTE function with the following signatures:
+//
+//    / a b
+//    (/ b) a
+//
+// Returns a divided by b.
 func Div(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) <= 1 {
 		return save(wdte.GoFunc(Div), args...)
@@ -101,9 +113,12 @@ func Div(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return a1.(wdte.Number) / a2.(wdte.Number)
 }
 
-// Mod returns args[0] % args[1]. If called with only 1 argument, it
-// returns a function which divides the original argument by its own
-// argument.
+// Mod is a WDTE function with the following signatures:
+//
+//    % a b
+//    (% b) a
+//
+// Returns a mod b.
 func Mod(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) <= 1 {
 		return save(wdte.GoFunc(Mod), args...)
@@ -127,13 +142,15 @@ func Mod(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	))
 }
 
-// Equals checks if two values are equal or not. If called with only
-// one argument, it returns a function which checks that argument for
-// equality with other values.
+// Equals is a WDTE function with the following signatures:
 //
-// If the first argument given implements wdte.Comparer, it is used
-// for the comparison. If not, and the second does, then that is used.
-// If neither does, a simple, direct Go equality check is used.
+//    == a b
+//    (== b) a
+//
+// Returns true if a equals b. If a implements wdte.Comparer, the
+// equality check is done using that implementation. If a does not but
+// b does, b's implementation is used. If neither does, a direct Go
+// equality check is used.
 func Equals(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) <= 1 {
 		return save(wdte.GoFunc(Equals), args...)
@@ -162,10 +179,15 @@ func Equals(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return wdte.Bool(a1 == a2)
 }
 
-// Less returns true if the first argument is less than the second.
-// It returns an error if two arguments can't be compared.
+// Less is a WDTE function with the following signatures:
 //
-// TODO: Document usage of wdte.Comparer.
+//    < a b
+//    (< b) a
+//
+// Returns true if a is less than b. Comparison rules are the same as
+// those used for Equals, with the exception that the argument used
+// must not only implement wdte.Comparer but that that implementation
+// must support ordering.
 func Less(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) <= 1 {
 		return save(wdte.GoFunc(Less), args...)
@@ -201,10 +223,15 @@ func Less(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	}
 }
 
-// Greater returns true if the first argument is less than the second.
-// It returns an error if two arguments can't be compared.
+// Greater is a WDTE function with the following signatures:
 //
-// TODO: Document usage of wdte.Comparer.
+//    > a b
+//    (> b) a
+//
+// Returns true if a is greater than b. Comparison rules are the same
+// as those used for Equals, with the exception that the argument used
+// must not only implement wdte.Comparer but that that implementation
+// must support ordering.
 func Greater(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) <= 1 {
 		return save(wdte.GoFunc(Greater), args...)
@@ -240,10 +267,15 @@ func Greater(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	}
 }
 
-// LessEqual returns true if the first argument is less than or equal
-// to the second.
+// LessEqual is a WDTE function with the following signatures:
 //
-// TODO: Document usage of wdte.Comparer.
+//    <= a b
+//    (<= b) a
+//
+// Returns true if a is less than or equal to b. Comparison rules are
+// the same as those used for Equals, with the exception that the
+// argument used must not only implement wdte.Comparer but that that
+// implementation must support ordering.
 func LessEqual(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) <= 1 {
 		return save(wdte.GoFunc(LessEqual), args...)
@@ -279,10 +311,15 @@ func LessEqual(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	}
 }
 
-// GreaterEqual returns true if the first argument is greater than or
-// equal to the second.
+// GreaterEqual is a WDTE function with the following signatures:
 //
-// TODO: Document usage of wdte.Comparer.
+//    >= a b
+//    (>= b) a
+//
+// Returns true if a is greater than or equal to b. Comparison rules
+// are the same as those used for Equals, with the exception that the
+// argument used must not only implement wdte.Comparer but that that
+// implementation must support ordering.
 func GreaterEqual(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) <= 1 {
 		return save(wdte.GoFunc(GreaterEqual), args...)
@@ -319,16 +356,28 @@ func GreaterEqual(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 }
 
 const (
-	// True returns a boolean true.
+	// True is a WDTE function with the following signature:
+	//
+	//    true
+	//
+	// As you can probably guess, it returns a boolean true.
 	True wdte.Bool = true
 
-	// False returns a boolean false. This is rarely necessary as most
+	// False is a WDTE function with the following signature:
+	//
+	//    false
+	//
+	// Returns a boolean false. This is rarely necessary as most
 	// built-in functionality considers any value other than a boolean
 	// true to be false, but it's provided for completeness.
 	False wdte.Bool = false
 )
 
-// And returns true if all of its arguments are true.
+// And is a WDTE function with the following signature:
+//
+//    && ...
+//
+// Returns true if all of its arguments are true.
 func And(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	frame = frame.Sub("&&")
 
@@ -347,7 +396,11 @@ func And(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return wdte.Bool(true)
 }
 
-// Or returns true if any of its arguments are true.
+// Or is a WDTE function with the following signature:
+//
+//    || ...
+//
+// Returns true if any of its arguments are true.
 func Or(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	frame = frame.Sub("||")
 
@@ -366,8 +419,11 @@ func Or(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return wdte.Bool(false)
 }
 
-// Not returns true if its argument isn't. Otherwise, it returns
-// false.
+// Not is a WDTE function with the following signature:
+//
+//    ! a
+//
+// Returns true if a is not true or false if a is not true.
 func Not(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	frame = frame.Sub("!")
 
@@ -379,8 +435,12 @@ func Not(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return wdte.Bool(args[0].Call(frame) != wdte.Bool(true))
 }
 
-// Len returns the length of anything that implements wdte.Lenner. If
-// its argument does not implement wdte.Lenner, it returns false.
+// Len is a WDTE function with the following signature:
+//
+//    len a
+//
+// Returns the length of a if a implements wdte.Lenner, or false if it
+// doesn't.
 func Len(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	frame = frame.Sub("len")
 
@@ -396,20 +456,12 @@ func Len(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return wdte.Bool(false)
 }
 
-// At returns the element at the index of the first argument, which is
-// assumed to be a wdte.Atter, specified by the second argument. In
-// other words,
+// At is a WDTE function with the following signatures:
 //
-//     at a i
+//    at a i
+//    (at i) a
 //
-// is the equivalent of
-//
-//     a[i]
-//
-// in a C-style language.
-//
-// If only given one argument, it returns a function which returns the
-// element at that index of its own argument.
+// Returns the ith index of a. a is assumed to implement wdte.Atter.
 func At(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) <= 1 {
 		return save(wdte.GoFunc(At), args...)
@@ -431,41 +483,35 @@ func At(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return ret
 }
 
-// S returns a scope containing all of the functions in this package.
-// It maps some functions to symbols, such as Add ("+"), Sub ("-"),
-// and Equals ("=="), and some to the same name that they have in here
-// but with the first letter lowercase, such as True ("true").
+// Scope is a scope containing the functions in this package.
 //
-// The scope returned from here is useful for skipping some simpler
-// boilerplate in a lot of cases. To use it, simply pass a frame
-// containing it or a subscope of it to a function call. In many
-// cases, it may be simpler to use the F function instead.
-func S() *wdte.Scope {
-	return wdte.S().Map(map[wdte.ID]wdte.Func{
-		"+": wdte.GoFunc(Add),
-		"-": wdte.GoFunc(Sub),
-		"*": wdte.GoFunc(Mult),
-		"/": wdte.GoFunc(Div),
-		"%": wdte.GoFunc(Mod),
+// This scope is primarily useful for bootstrapping an environment for
+// running scripts in. To use it, simply pass a frame containing it or
+// a subscope of it to a function call. In many cases, a client can
+// simply call F to obtain such a frame.
+var Scope = wdte.S().Map(map[wdte.ID]wdte.Func{
+	"+": wdte.GoFunc(Add),
+	"-": wdte.GoFunc(Sub),
+	"*": wdte.GoFunc(Mult),
+	"/": wdte.GoFunc(Div),
+	"%": wdte.GoFunc(Mod),
 
-		"==":    wdte.GoFunc(Equals),
-		"<":     wdte.GoFunc(Less),
-		">":     wdte.GoFunc(Greater),
-		"<=":    wdte.GoFunc(LessEqual),
-		">=":    wdte.GoFunc(GreaterEqual),
-		"true":  True,
-		"false": False,
-		"&&":    wdte.GoFunc(And),
-		"||":    wdte.GoFunc(Or),
-		"!":     wdte.GoFunc(Not),
+	"==":    wdte.GoFunc(Equals),
+	"<":     wdte.GoFunc(Less),
+	">":     wdte.GoFunc(Greater),
+	"<=":    wdte.GoFunc(LessEqual),
+	">=":    wdte.GoFunc(GreaterEqual),
+	"true":  True,
+	"false": False,
+	"&&":    wdte.GoFunc(And),
+	"||":    wdte.GoFunc(Or),
+	"!":     wdte.GoFunc(Not),
 
-		"len": wdte.GoFunc(Len),
-		"at":  wdte.GoFunc(At),
-	})
-}
+	"len": wdte.GoFunc(Len),
+	"at":  wdte.GoFunc(At),
+})
 
-// F returns a top-level frame that has the various functions in this
-// package already in scope.
+// F returns a top-level frame that has S as its scope.
 func F() wdte.Frame {
-	return wdte.F().WithScope(S())
+	return wdte.F().WithScope(Scope)
 }

--- a/std/stream/end.go
+++ b/std/stream/end.go
@@ -2,12 +2,12 @@ package stream
 
 import "github.com/DeedleFake/wdte"
 
-// Collect iterates over a stream, putting each of its elements into a
-// new array, in the order they are yielded by the stream, before
-// returning the array.
+// Collect is a WDTE function with the following signature:
 //
-// If any of the values yielded by the stream are errors, then
-// iteration stops and that error is returned instead.
+//    collect s
+//
+// Iterates through the Stream s, collecting the yielded elements into
+// an array. When the Stream ends, it returns the collected array.
 func Collect(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	switch len(args) {
 	case 0:
@@ -37,16 +37,15 @@ func Collect(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return r
 }
 
-// Drain drains the stream, iterating over it much like collect does,
-// but discarding each value. When it's finished it returns the
-// now-empty stream. If an error is yielded by the stream, then
-// iteration stops and that error is returned instead.
+// Drain is a WDTE function with the following signature:
 //
-// The primary purpose of this function is to allow map to be used as
-// a type of foreach-style loop without the extra allocation that
-// collect performs. For example:
+//    drain s
 //
-//     s.range 5 -> s.map (io.writeln io.stdout) -> s.drain;
+// Drain is the same as Collect, but it simply discards elements as
+// they are yielded by the Stream, returning the empty Stream when
+// it's done. The main purpose of this function is to allow Map to be
+// used as a foreach-style loop without the allocation that Collect
+// performs.
 func Drain(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	switch len(args) {
 	case 0:
@@ -67,20 +66,27 @@ func Drain(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	}
 }
 
-// Reduce reduces a stream to a single value using a reduction
-// function. For example,
+// Reduce is a WDTE function with the following signatures:
 //
-//     s.range 5 -> s.reduce 0 +
+//    reduce s i r
+//    (reduce r) s i
+//    (reduce i r) s
 //
-// will yield a summation of the number 0 through 4, inclusive.
+// Reduce performs a reduction on the Stream s, resulting in a single
+// value, which is returned. i is the initial value for the reduction,
+// and r is the reducer. r is expected to have the following
+// signature:
 //
-// Reduce takes three arguments: A stream, an initial value, and a
-// function. It first calls the reduction function with the initial
-// value given and the first value from the stream. It then continues
-// iterating over every value in the stream, passing both the previous
-// output of the reduction function and the value the stream yielded
-// until the stream is empty, at which point it returns the most
-// recent output from the reduction function.
+//    r acc n
+//
+// r is passed the accumulated value as acc, starting with i, and the
+// latest value yielded by the Stream as n. Whatever value r returns
+// is used as the next value of acc until the Stream is empty, at
+// which point the last value of acc is returned. For example,
+//
+//    range 5 -> reduce 0 +
+//
+// returns a summation of the range [0,5).
 func Reduce(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	frame = frame.Sub("reduce")
 
@@ -146,15 +152,14 @@ func Reduce(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 //	return prev
 //}
 
-// Any takes two arguments, a stream and a function. It iterates over
-// the stream's values, calling the given function on each element. If
-// any of the calls return true, than the whole function returns true.
-// If it reaches the end of the stream, then it returns
-// false.
+// Any is a WDTE function with the following signatures:
 //
-// If given only one argument, it returns a function which checks its
-// own argument, a stream, against the function it was originally
-// given.
+//    any s f
+//    (any f) s
+//
+// It iterates over the Stream s, passing each yielded element to f in
+// turn. If any of those calls returns true, then the entire function
+// returns true. Otherwise it returns false. It is short-circuiting.
 func Any(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	switch len(args) {
 	case 0:
@@ -182,15 +187,14 @@ func Any(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	}
 }
 
-// All takes two arguments, a stream and a function. It iterates over
-// the stream's values, calling the given function on each element. If
-// any of the calls don't return true, than the whole function returns
-// false. If it reaches the end of the stream, then it returns
-// true.
+// All is a WDTE function with the following signatures:
 //
-// If given only one argument, it returns a function which checks its
-// own argument, a stream, against the function it was originally
-// given.
+//    all s f
+//    (all f) s
+//
+// It iterates over the Stream s, passing each yielded element to f in
+// turn. If all of those calls return true, then the entire function
+// returns true. Otherwise it returns false. It is short-circuiting.
 func All(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	switch len(args) {
 	case 0:

--- a/std/stream/stream.go
+++ b/std/stream/stream.go
@@ -49,5 +49,5 @@ var Scope = wdte.S().Map(map[wdte.ID]wdte.Func{
 })
 
 func init() {
-	std.Register("stream", S())
+	std.Register("stream", Scope)
 }

--- a/std/stream/stream.go
+++ b/std/stream/stream.go
@@ -29,26 +29,24 @@ func (n NextFunc) Next(frame wdte.Frame) (wdte.Func, bool) { // nolint
 	return n(frame)
 }
 
-// S returns a scope containing the various functions in this package.
-func S() *wdte.Scope {
-	return wdte.S().Map(map[wdte.ID]wdte.Func{
-		"new":    wdte.GoFunc(New),
-		"range":  wdte.GoFunc(Range),
-		"concat": wdte.GoFunc(Concat),
+// Scope is a scope containing the functions in this package.
+var Scope = wdte.S().Map(map[wdte.ID]wdte.Func{
+	"new":    wdte.GoFunc(New),
+	"range":  wdte.GoFunc(Range),
+	"concat": wdte.GoFunc(Concat),
 
-		"map":       wdte.GoFunc(Map),
-		"filter":    wdte.GoFunc(Filter),
-		"flatMap":   wdte.GoFunc(FlatMap),
-		"enumerate": wdte.GoFunc(Enumerate),
+	"map":       wdte.GoFunc(Map),
+	"filter":    wdte.GoFunc(Filter),
+	"flatMap":   wdte.GoFunc(FlatMap),
+	"enumerate": wdte.GoFunc(Enumerate),
 
-		"collect": wdte.GoFunc(Collect),
-		"drain":   wdte.GoFunc(Drain),
-		"reduce":  wdte.GoFunc(Reduce),
-		//"chain":   wdte.GoFunc(Chain),
-		"any": wdte.GoFunc(Any),
-		"all": wdte.GoFunc(All),
-	})
-}
+	"collect": wdte.GoFunc(Collect),
+	"drain":   wdte.GoFunc(Drain),
+	"reduce":  wdte.GoFunc(Reduce),
+	//"chain":   wdte.GoFunc(Chain),
+	"any": wdte.GoFunc(Any),
+	"all": wdte.GoFunc(All),
+})
 
 func init() {
 	std.Register("stream", S())

--- a/std/strings/format.go
+++ b/std/strings/format.go
@@ -12,12 +12,17 @@ import (
 	"github.com/DeedleFake/wdte"
 )
 
-// Format formats a string. The first argument is a format
-// specification, and all trailing arguments are values to be
-// formatted into the string. It does *not* use Go's C-style
-// formatting specification. Instead, format specifications are {}
-// with optional flags placed between them. Flags may be any
-// combination of the following:
+// Format is a WDTE function with the following signatures:
+//
+//    format tmpl ...
+//    (format tmpl) ...
+//
+// This is the general-purpose string formatting function of the
+// standard library, similar to Go's fmt.Sprintf(). Unlike
+// fmt.Sprintf(), however, format uses a custom formatting
+// specification. A format in the string tmpl is of the form {} with
+// optional flags placed between them. Flags may be any combination of
+// the following:
 //
 //    #<num> The zero-based index of the argument to be inserted.
 //           Subsequent formats will increment from here. In other
@@ -26,10 +31,6 @@ import (
 //    q      Place the value in quotes using strconv.Quote.
 //    ?      Mark the value with it's underlying Go type, such as
 //           wdte.Number(3).
-//
-// Any unknown flags will cause an error to be returned instead.
-//
-// If Format is only given one argument, it returns a function that formats its own arguments using that original argument as the format specification.
 //
 // TODO: Add more flags.
 func Format(frame wdte.Frame, args ...wdte.Func) wdte.Func {

--- a/std/strings/strings.go
+++ b/std/strings/strings.go
@@ -8,9 +8,12 @@ import (
 	"github.com/DeedleFake/wdte/std"
 )
 
-// Contains returns true if the second argument is a substring of the
-// first. If only given one argument, it returns a function that
-// checks if that argument is a substring of its own argument.
+// Contains is a WDTE function with the following signatures:
+//
+//    contains outer inner
+//    (contains inner) outer
+//
+// Returns true if inner is a substring of outer.
 func Contains(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	frame = frame.Sub("contains")
 
@@ -29,9 +32,12 @@ func Contains(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return wdte.Bool(strings.Contains(string(haystack), string(needle)))
 }
 
-// Prefix returns true if the first argument starts with the second.
-// If given only one argument, it returns a function that checks if
-// that argument is a prefix of its own argument.
+// Prefix is a WDTE function with the following signatures:
+//
+//    prefix s p
+//    (prefix p) s
+//
+// Returns true if p is a prefix of s.
 func Prefix(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	frame = frame.Sub("prefix")
 
@@ -50,9 +56,12 @@ func Prefix(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return wdte.Bool(strings.HasPrefix(string(haystack), string(needle)))
 }
 
-// Suffix returns true if the first argument ends with the second. If
-// given only one argument, it returns a function that checks if that
-// argument is a suffix of its own argument.
+// Suffix is a WDTE function with the following signatures:
+//
+//    suffix s p
+//    (suffix p) s
+//
+// Returns true if p is a suffix of s.
 func Suffix(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	frame = frame.Sub("suffix")
 
@@ -71,10 +80,14 @@ func Suffix(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return wdte.Bool(strings.HasSuffix(string(haystack), string(needle)))
 }
 
-// Index searches the first argument for the second argument,
-// returning the index of the beginning of its first instance, or -1
-// if its not present. If only given one argument, Index returns a
-// function which searches other strings for that argument.
+// Index is a WDTE function with the following signatures:
+//
+//    index outer inner
+//    (index inner) outer
+//
+// It returns the index of the first character of the first instances
+// of inner in outer. If inner is not a substring of outer, it returns
+// -1.
 func Index(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	frame = frame.Sub("index")
 
@@ -93,7 +106,11 @@ func Index(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return wdte.Number(strings.Index(string(haystack), string(needle)))
 }
 
-// Upper returns its argument converted to uppercase.
+// Upper is a WDTE function with the following signatures:
+//
+//    upper s
+//
+// It returns s converted to uppercase.
 func Upper(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	frame = frame.Sub("upper")
 
@@ -105,7 +122,11 @@ func Upper(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return wdte.String(strings.ToUpper(string(args[0].Call(frame).(wdte.String))))
 }
 
-// Lower returns its argument converted to lowercase.
+// Lower is a WDTE function with the following signature:
+//
+//    lower s
+//
+// It returns s converted to lowercase.
 func Lower(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	frame = frame.Sub("lower")
 
@@ -117,21 +138,19 @@ func Lower(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return wdte.String(strings.ToLower(string(args[0].Call(frame).(wdte.String))))
 }
 
-// S returns a scope containing the various functions in this package.
-func S() *wdte.Scope {
-	return wdte.S().Map(map[wdte.ID]wdte.Func{
-		"contains": wdte.GoFunc(Contains),
-		"prefix":   wdte.GoFunc(Prefix),
-		"suffix":   wdte.GoFunc(Suffix),
-		"index":    wdte.GoFunc(Index),
+// Scope is a scope containing the functions in this package.
+var Scope = wdte.S().Map(map[wdte.ID]wdte.Func{
+	"contains": wdte.GoFunc(Contains),
+	"prefix":   wdte.GoFunc(Prefix),
+	"suffix":   wdte.GoFunc(Suffix),
+	"index":    wdte.GoFunc(Index),
 
-		"upper": wdte.GoFunc(Upper),
-		"lower": wdte.GoFunc(Lower),
+	"upper": wdte.GoFunc(Upper),
+	"lower": wdte.GoFunc(Lower),
 
-		"format": wdte.GoFunc(Format),
-	})
-}
+	"format": wdte.GoFunc(Format),
+})
 
 func init() {
-	std.Register("strings", S())
+	std.Register("strings", Scope)
 }

--- a/wdte_test.go
+++ b/wdte_test.go
@@ -106,8 +106,8 @@ func runTests(t *testing.T, tests []test) {
 func TestBasics(t *testing.T) {
 	t.Run("ScopeKnown", func(t *testing.T) {
 		scope := wdte.S()
-		scope = scope.Sub("x", wdte.Number(3))
-		scope = scope.Sub("test", wdte.String("This is a test."))
+		scope = scope.Add("x", wdte.Number(3))
+		scope = scope.Add("test", wdte.String("This is a test."))
 		scope = scope.Map(map[wdte.ID]wdte.Func{
 			"q":    wdte.String("Other"),
 			"test": wdte.String("Or is it?"),

--- a/wdte_test.go
+++ b/wdte_test.go
@@ -357,10 +357,20 @@ func TestStream(t *testing.T) {
 			ret:    wdte.Array{wdte.Number(3), wdte.Number(6), wdte.Number(9)},
 		},
 		{
-			name:   "Range",
+			name:   "Range/1",
 			script: `let s => import 'stream'; let main start end step => s.range start end step -> s.collect;`,
 			args:   []wdte.Func{wdte.Number(3), wdte.Number(12), wdte.Number(3)},
 			ret:    wdte.Array{wdte.Number(3), wdte.Number(6), wdte.Number(9)},
+		},
+		{
+			name:   "Range/2",
+			script: `let s => import 'stream'; s.range 1 3 -> s.collect;`,
+			ret:    wdte.Array{wdte.Number(1), wdte.Number(2)},
+		},
+		{
+			name:   "Range/3",
+			script: `let s => import 'stream'; s.range 1 6 2 -> s.collect;`,
+			ret:    wdte.Array{wdte.Number(1), wdte.Number(3), wdte.Number(5)},
 		},
 		{
 			name:   "Concat",


### PR DESCRIPTION
All documentation for WDTE functions is now in the form

```go
// <name> is a WDTE function with the following signatures:
//
//    <name> some args
//    (<name> some) args
//
// <description>
```

This hopefully makes it much, much easier to see at a glance how to use each function.

Along with this, a number of tweaks have been made:

* `std/stream`: Range now handles negative step values.
* `wdte`: A few tweaks to the `Scope` API.