### PR TITLE
multiple: Add support for using scopes as objects.

### DIFF
--- a/std/std.go
+++ b/std/std.go
@@ -483,6 +483,25 @@ func At(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return ret
 }
 
+// Objectify is a WDTE function with the following signature:
+//
+//    objectify compound
+//
+// Objectify takes a compound as its argument and returns the scope
+// collected from executing that compound. The argument must be a
+// compound or the function will fail.
+func Objectify(frame wdte.Frame, args ...wdte.Func) wdte.Func {
+	if len(args) == 0 {
+		return wdte.GoFunc(Objectify)
+	}
+
+	frame = frame.Sub("objectify")
+
+	// TODO: Figure out cleaner way to do this?
+	s, _ := args[0].(*wdte.ScopedFunc).Func.(wdte.Compound).Collect(frame)
+	return s
+}
+
 // Scope is a scope containing the functions in this package.
 //
 // This scope is primarily useful for bootstrapping an environment for
@@ -507,8 +526,9 @@ var Scope = wdte.S().Map(map[wdte.ID]wdte.Func{
 	"||":    wdte.GoFunc(Or),
 	"!":     wdte.GoFunc(Not),
 
-	"len": wdte.GoFunc(Len),
-	"at":  wdte.GoFunc(At),
+	"len":       wdte.GoFunc(Len),
+	"at":        wdte.GoFunc(At),
+	"objectify": wdte.GoFunc(Objectify),
 })
 
 // F returns a top-level frame that has S as its scope.

--- a/std/std.go
+++ b/std/std.go
@@ -13,15 +13,15 @@ func save(f wdte.Func, saved ...wdte.Func) wdte.Func {
 	})
 }
 
-// Add is a WDTE function with the following signatures:
+// Plus is a WDTE function with the following signatures:
 //
 //    + a ...
 //    (+ a) ...
 //
 // Returns the sum of a and the rest of its arguments.
-func Add(frame wdte.Frame, args ...wdte.Func) wdte.Func {
+func Plus(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) <= 1 {
-		return save(wdte.GoFunc(Add), args...)
+		return save(wdte.GoFunc(Plus), args...)
 	}
 
 	frame = frame.Sub("+")
@@ -37,15 +37,15 @@ func Add(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return sum
 }
 
-// Sub is a WDTE with the following signatures:
+// Minus is a WDTE with the following signatures:
 //
 //    - a b
 //    (- b) a
 //
 // Returns a minus b.
-func Sub(frame wdte.Frame, args ...wdte.Func) wdte.Func {
+func Minus(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) <= 1 {
-		return save(wdte.GoFunc(Sub), args...)
+		return save(wdte.GoFunc(Minus), args...)
 	}
 
 	frame = frame.Sub("-")
@@ -63,15 +63,15 @@ func Sub(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return a1.(wdte.Number) - a2.(wdte.Number)
 }
 
-// Mult is a WDTE function with the following signatures:
+// Times is a WDTE function with the following signatures:
 //
 //    * a ...
 //    (* a) ...
 //
 // Returns the product of a and its other arguments.
-func Mult(frame wdte.Frame, args ...wdte.Func) wdte.Func {
+func Times(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) <= 1 {
-		return save(wdte.GoFunc(Mult), args...)
+		return save(wdte.GoFunc(Times), args...)
 	}
 
 	frame = frame.Sub("*")
@@ -502,6 +502,28 @@ func Objectify(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return s
 }
 
+// Sub is a WDTE function with the following signatures:
+//
+//    sub scope id val
+//    (sub val) scope id
+//    (sub id val) scope
+//
+// Sub returns a subscope of scope with the value val bound to the ID
+// id. It puts a "compound" lower bound on the scope.
+func Sub(frame wdte.Frame, args ...wdte.Func) wdte.Func {
+	if len(args) <= 2 {
+		return save(wdte.GoFunc(Sub), args...)
+	}
+
+	frame = frame.Sub("sub")
+
+	s := args[0].Call(frame).(*wdte.Scope)
+	id := wdte.ID(args[1].Call(frame).(wdte.String))
+	v := args[2]
+
+	return s.Add(id, v).LowerBound("compound")
+}
+
 // Scope is a scope containing the functions in this package.
 //
 // This scope is primarily useful for bootstrapping an environment for
@@ -509,9 +531,9 @@ func Objectify(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 // a subscope of it to a function call. In many cases, a client can
 // simply call F to obtain such a frame.
 var Scope = wdte.S().Map(map[wdte.ID]wdte.Func{
-	"+": wdte.GoFunc(Add),
-	"-": wdte.GoFunc(Sub),
-	"*": wdte.GoFunc(Mult),
+	"+": wdte.GoFunc(Plus),
+	"-": wdte.GoFunc(Minus),
+	"*": wdte.GoFunc(Times),
 	"/": wdte.GoFunc(Div),
 	"%": wdte.GoFunc(Mod),
 
@@ -529,6 +551,7 @@ var Scope = wdte.S().Map(map[wdte.ID]wdte.Func{
 	"len":       wdte.GoFunc(Len),
 	"at":        wdte.GoFunc(At),
 	"objectify": wdte.GoFunc(Objectify),
+	"sub":       wdte.GoFunc(Sub),
 })
 
 // F returns a top-level frame that has S as its scope.

--- a/std/std.go
+++ b/std/std.go
@@ -490,16 +490,19 @@ func At(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 // Objectify takes a compound as its argument and returns the scope
 // collected from executing that compound. The argument must be a
 // compound or the function will fail.
+//
+// It surrounds the returned scope with a bound called "object".
 func Objectify(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) == 0 {
 		return wdte.GoFunc(Objectify)
 	}
 
 	frame = frame.Sub("objectify")
+	frame = frame.WithScope(frame.Scope().UpperBound())
 
 	// TODO: Figure out cleaner way to do this?
 	s, _ := args[0].(*wdte.ScopedFunc).Func.(wdte.Compound).Collect(frame)
-	return s
+	return s.LowerBound("object")
 }
 
 // Sub is a WDTE function with the following signatures:
@@ -509,7 +512,8 @@ func Objectify(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 //    (sub id val) scope
 //
 // Sub returns a subscope of scope with the value val bound to the ID
-// id. It puts a "compound" lower bound on the scope.
+// id. It puts a "object" lower bound on the scope but does not add
+// any upper bounds.
 func Sub(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	if len(args) <= 2 {
 		return save(wdte.GoFunc(Sub), args...)
@@ -521,7 +525,7 @@ func Sub(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	id := wdte.ID(args[1].Call(frame).(wdte.String))
 	v := args[2]
 
-	return s.Add(id, v).LowerBound("compound")
+	return s.Add(id, v).LowerBound("object")
 }
 
 // Scope is a scope containing the functions in this package.

--- a/wdte.go
+++ b/wdte.go
@@ -553,11 +553,8 @@ type Compound []Func
 // alongside the usual return value. This is useful when dealing with
 // scopes as modules, as it allows you to evaluate specific functions
 // in a script.
-//
-// Collect automatically surrounds the returned scope with a
-// "compound" bound.
 func (c Compound) Collect(frame Frame, args ...Func) (*Scope, Func) {
-	frame = frame.WithScope(frame.Scope().UpperBound())
+	frame = frame.WithScope(frame.Scope())
 
 	var last Func
 	for _, f := range c {
@@ -581,7 +578,7 @@ func (c Compound) Collect(frame Frame, args ...Func) (*Scope, Func) {
 		last = last.Call(frame, args...)
 	}
 
-	return frame.Scope().LowerBound("compound"), last
+	return frame.Scope(), last
 }
 
 func (c Compound) Call(frame Frame, args ...Func) Func { // nolint

--- a/wdte.go
+++ b/wdte.go
@@ -553,7 +553,12 @@ type Compound []Func
 // alongside the usual return value. This is useful when dealing with
 // scopes as modules, as it allows you to evaluate specific functions
 // in a script.
+//
+// Collect automatically surrounds the returned scope with a
+// "compound" bound.
 func (c Compound) Collect(frame Frame, args ...Func) (*Scope, Func) {
+	frame = frame.WithScope(frame.Scope().UpperBound())
+
 	var last Func
 	for _, f := range c {
 		switch f := f.(type) {
@@ -576,7 +581,7 @@ func (c Compound) Collect(frame Frame, args ...Func) (*Scope, Func) {
 		last = last.Call(frame, args...)
 	}
 
-	return frame.Scope(), last
+	return frame.Scope().LowerBound("compound"), last
 }
 
 func (c Compound) Call(frame Frame, args ...Func) Func { // nolint

--- a/wdte.go
+++ b/wdte.go
@@ -403,6 +403,11 @@ func (s *Scope) String() string { // nolint
 	return fmt.Sprint(s.Known())
 }
 
+func (s *Scope) At(i Func) (Func, bool) { // nolint
+	v := s.Get(ID(i.(String)))
+	return v, v != nil
+}
+
 // A GoFunc is an implementation of Func that calls a Go function.
 // This is the easiest way to implement lower-level systems for WDTE
 // scripts to make use of.

--- a/wdte_test.go
+++ b/wdte_test.go
@@ -323,6 +323,11 @@ func TestBasics(t *testing.T) {
 			script: `let t => objectify (let test => 3); t.test;`,
 			ret:    wdte.Number(3),
 		},
+		{
+			name:   "Sub",
+			script: `let t => objectify (let test => 3); let t => sub t 'test2' 5; t.test2;`,
+			ret:    wdte.Number(5),
+		},
 	})
 }
 

--- a/wdte_test.go
+++ b/wdte_test.go
@@ -318,6 +318,11 @@ func TestBasics(t *testing.T) {
 			script: `let m => import 'math'; at m 'pi';`,
 			ret:    wdte.Number(math.Pi),
 		},
+		{
+			name:   "Objectify",
+			script: `let t => objectify (let test => 3); t.test;`,
+			ret:    wdte.Number(3),
+		},
 	})
 }
 

--- a/wdte_test.go
+++ b/wdte_test.go
@@ -68,10 +68,7 @@ func runTests(t *testing.T, tests []test) {
 				t.Fatalf("Failed to parse script: %v", err)
 			}
 
-			ret := m.Call(std.F())
-			if len(test.args) > 0 {
-				ret = ret.Call(std.F(), test.args...)
-			}
+			ret := m.Call(std.F()).Call(std.F(), test.args...)
 
 			switch test.ret {
 			case nil:
@@ -315,6 +312,11 @@ func TestBasics(t *testing.T) {
 			name:   "At/Array",
 			script: `at [3; 5; 1] 0;`,
 			ret:    wdte.Number(3),
+		},
+		{
+			name:   "At/Scope",
+			script: `let m => import 'math'; at m 'pi';`,
+			ret:    wdte.Number(math.Pi),
 		},
 	})
 }


### PR DESCRIPTION
Closes #85. Unlike that issues specifies, however, the bounds creation is done in `objectify` and `sub`, rather than in `Scope.Collect()`.