### PR TITLE
wdte: Call function of `Expr` before passing it arguments.

### DIFF
--- a/std/stream/middle.go
+++ b/std/stream/middle.go
@@ -105,7 +105,7 @@ type flatMapper struct {
 func FlatMap(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	switch len(args) {
 	case 0:
-		return wdte.GoFunc(Map)
+		return wdte.GoFunc(FlatMap)
 	}
 
 	return &flatMapper{m: args[0].Call(frame)}

--- a/wdte.go
+++ b/wdte.go
@@ -467,7 +467,7 @@ func (f Expr) Call(frame Frame, args ...Func) Func { // nolint
 		next[i] = frame.Scope().Freeze(f.Args[i])
 	}
 
-	return f.Func.Call(frame, next...)
+	return f.Func.Call(frame).Call(frame, next...)
 }
 
 // Chain is an unevaluated chain expression.

--- a/wdte_test.go
+++ b/wdte_test.go
@@ -170,6 +170,11 @@ func TestBasics(t *testing.T) {
 			ret:    wdte.Number(8),
 		},
 		{
+			name:   "Simple/VariableArgs",
+			script: `let test => +; test 3 5;`,
+			ret:    wdte.Number(8),
+		},
+		{
 			name:   "Chain",
 			script: `1 -> + 2 -> - 3;`,
 			ret:    wdte.Number(0),


### PR DESCRIPTION
Fixes #94.