### PR TITLE
wdte: Some Minor README Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ I had a number of design goals in mind when I started working on this project:
 * Designed primarily for embedding. No command-line interpreter by default.
 * Extremely easy to use from the binding side. In this case, that's primarily Go.
 
-If you want to try the language yourself, feel free to take a look at [the playground][playground]. It shows not only some of the features of the language in terms of actually writing code in it, but also how embeddable it is. The playground runs entirely in the browser *on the client's end* thanks to [GopherJS][gopherjs].
+If you want to try the language yourself, feel free to take a look at [the playground][playground]. It shows not only some of the features of the language in terms of actually writing code in it, but also how embeddable it is. The playground runs entirely in the browser *on the client's end* thanks to WebAssembly.
 
 Example
 -------
 
-```
+```go
 package main
 
 import (
@@ -96,5 +96,4 @@ Status
 WDTE is in a pre-alpha state. It is filled with bugs and large amounts of stuff are subject to change without warning. That being said, if you're interested in anything, feel free to submit a pull request and get things fixed and/or implemented faster.
 
 [playground]: https://deedlefake.github.io/wdte
-[gopherjs]: https://github.com/gopherjs/gopherjs
 [wiki]: https://github.com/DeedleFake/wdte/wiki


### PR DESCRIPTION
* Remove GopherJS references and replace with WebAssembly.
* Add syntax highlighting to example.