### PR TITLE
all: Add Reflection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,5 @@ module github.com/DeedleFake/wdte
 require (
 	github.com/peterh/liner v1.1.0
 	golang.org/x/crypto v0.0.0-20181025213731-e84da0312774
-	golang.org/x/sys v0.0.0-20181026144532-2772b66316d2 // indirect
+	golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,5 @@ github.com/peterh/liner v1.1.0 h1:f+aAedNJA6uk7+6rXsYBnhdo4Xux7ESLe+kcuVUF5os=
 github.com/peterh/liner v1.1.0/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
 golang.org/x/crypto v0.0.0-20181025213731-e84da0312774 h1:a4tQYYYuK9QdeO/+kEvNYyuR21S+7ve5EANok6hABhI=
 golang.org/x/crypto v0.0.0-20181025213731-e84da0312774/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/sys v0.0.0-20181026144532-2772b66316d2 h1:W7CqTdBJ1CmxLKe7LptKDnBYV6PHrVLiGnoyBjaG/JQ=
-golang.org/x/sys v0.0.0-20181026144532-2772b66316d2/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5 h1:x6r4Jo0KNzOOzYd8lbcRsqjuqEASK6ob3auvWYM4/8U=
+golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/std/arrays/arrays.go
+++ b/std/arrays/arrays.go
@@ -165,6 +165,10 @@ func (a *streamer) String() string { // nolint
 	return "<stream>"
 }
 
+func (a *streamer) Reflect(name string) { // nolint
+	return name == "Stream"
+}
+
 // Scope is a scope containing the functions in this package.
 var Scope = wdte.S().Map(map[wdte.ID]wdte.Func{
 	"concat":     wdte.GoFunc(Concat),

--- a/std/arrays/arrays.go
+++ b/std/arrays/arrays.go
@@ -165,7 +165,7 @@ func (a *streamer) String() string { // nolint
 	return "<stream>"
 }
 
-func (a *streamer) Reflect(name string) { // nolint
+func (a *streamer) Reflect(name string) bool { // nolint
 	return name == "Stream"
 }
 

--- a/std/io/io.go
+++ b/std/io/io.go
@@ -37,7 +37,7 @@ func (stdin) String() string {
 	return "<reader(stdin)>"
 }
 
-func (stdin) Reflect(name string) { // nolint
+func (stdin) Reflect(name string) bool { // nolint
 	return name == "Reader"
 }
 
@@ -55,7 +55,7 @@ func (stdout) String() string {
 	return "<writer(stdout)>"
 }
 
-func (stdout) Reflect(name string) { // nolint
+func (stdout) Reflect(name string) bool { // nolint
 	return name == "Writer"
 }
 
@@ -73,7 +73,7 @@ func (stderr) String() string {
 	return "<writer(stderr)>"
 }
 
-func (stderr) Reflect(name string) { // nolint
+func (stderr) Reflect(name string) bool { // nolint
 	return name == "Writer"
 }
 
@@ -104,7 +104,7 @@ func (r Reader) String() string { // nolint
 	return "<reader>"
 }
 
-func (r Reader) Reflect(name string) { // nolint
+func (r Reader) Reflect(name string) bool { // nolint
 	return name == "Reader"
 }
 
@@ -135,7 +135,7 @@ func (w Writer) String() string { // nolint
 	return "<writer>"
 }
 
-func (w Writer) Reflect(name string) { // nolint
+func (w Writer) Reflect(name string) bool { // nolint
 	return name == "Writer"
 }
 
@@ -307,7 +307,7 @@ func (r stringReader) Call(frame wdte.Frame, args ...wdte.Func) wdte.Func { // n
 	return r
 }
 
-func (r stringReader) Reflect(name string) { // nolint
+func (r stringReader) Reflect(name string) bool { // nolint
 	return name == "Reader"
 }
 
@@ -373,7 +373,7 @@ func (s scanner) Next(frame wdte.Frame) (wdte.Func, bool) { // nolint
 	return wdte.String(s.s.Text()), true
 }
 
-func (s scanner) Reflect(name string) { // nolint
+func (s scanner) Reflect(name string) bool { // nolint
 	return name == "Stream"
 }
 
@@ -491,7 +491,7 @@ func (r runeStream) Next(frame wdte.Frame) (wdte.Func, bool) { // nolint
 	return wdte.Number(c), true
 }
 
-func (r runeStream) Reflect(name string) { // nolint
+func (r runeStream) Reflect(name string) bool { // nolint
 	return name == "Stream"
 }
 

--- a/std/io/io.go
+++ b/std/io/io.go
@@ -37,6 +37,10 @@ func (stdin) String() string {
 	return "<reader(stdin)>"
 }
 
+func (stdin) Reflect(name string) { // nolint
+	return name == "Reader"
+}
+
 type stdout struct{}
 
 func (w stdout) Call(frame wdte.Frame, args ...wdte.Func) wdte.Func {
@@ -51,6 +55,10 @@ func (stdout) String() string {
 	return "<writer(stdout)>"
 }
 
+func (stdout) Reflect(name string) { // nolint
+	return name == "Writer"
+}
+
 type stderr struct{}
 
 func (w stderr) Call(frame wdte.Frame, args ...wdte.Func) wdte.Func {
@@ -63,6 +71,10 @@ func (stderr) Write(data []byte) (int, error) {
 
 func (stderr) String() string {
 	return "<writer(stderr)>"
+}
+
+func (stderr) Reflect(name string) { // nolint
+	return name == "Writer"
 }
 
 type reader interface {
@@ -92,6 +104,10 @@ func (r Reader) String() string { // nolint
 	return "<reader>"
 }
 
+func (r Reader) Reflect(name string) { // nolint
+	return name == "Reader"
+}
+
 type writer interface {
 	wdte.Func
 	io.Writer
@@ -117,6 +133,10 @@ func (w Writer) String() string { // nolint
 	}
 
 	return "<writer>"
+}
+
+func (w Writer) Reflect(name string) { // nolint
+	return name == "Writer"
 }
 
 // Seek is a WDTE function with the following signatures:
@@ -287,6 +307,10 @@ func (r stringReader) Call(frame wdte.Frame, args ...wdte.Func) wdte.Func { // n
 	return r
 }
 
+func (r stringReader) Reflect(name string) { // nolint
+	return name == "Reader"
+}
+
 // ReadString is a WDTE function with the following signature:
 //
 //    readString s
@@ -305,7 +329,7 @@ func ReadString(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 
 // String is a WDTE function with the following signature:
 //
-//    strings r
+//    string r
 //
 // Reads the entirety of the reader r and returns the result as a
 // string.
@@ -347,6 +371,10 @@ func (s scanner) Next(frame wdte.Frame) (wdte.Func, bool) { // nolint
 	}
 
 	return wdte.String(s.s.Text()), true
+}
+
+func (s scanner) Reflect(name string) { // nolint
+	return name == "Stream"
 }
 
 // Lines is a WDTE function with the following signature:
@@ -461,6 +489,10 @@ func (r runeStream) Next(frame wdte.Frame) (wdte.Func, bool) { // nolint
 		return wdte.Error{Frame: frame, Err: err}, true
 	}
 	return wdte.Number(c), true
+}
+
+func (r runeStream) Reflect(name string) { // nolint
+	return name == "Stream"
 }
 
 // Runes is a WDTE function with the following signature:

--- a/std/std.go
+++ b/std/std.go
@@ -4,6 +4,7 @@ package std
 import (
 	"fmt"
 	"math"
+	"reflect"
 
 	"github.com/DeedleFake/wdte"
 )
@@ -553,6 +554,29 @@ func Sub(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	return s.Add(id, v)
 }
 
+// Reflect is a WDTE function with the following signature:
+//
+//    reflect v
+//
+// It returns a string that identifies the type of the value given. If
+// the value's type implements wdte.Reflector, v.Reflect() is
+// returned. If not, a name is generated using Go's reflect package.
+func Reflect(frame wdte.Frame, args ...wdte.Func) wdte.Func {
+	frame = frame.Sub("reflect")
+
+	switch len(args) {
+	case 0:
+		return wdte.GoFunc(Reflect)
+	}
+
+	a := args[0].Call(frame)
+	if r, ok := a.(wdte.Reflector); ok {
+		return wdte.String(r.Reflect())
+	}
+
+	return wdte.String(reflect.TypeOf(a).Name())
+}
+
 // Scope is a scope containing the functions in this package.
 //
 // This scope is primarily useful for bootstrapping an environment for
@@ -582,6 +606,7 @@ var Scope = wdte.S().Map(map[wdte.ID]wdte.Func{
 	"collect": wdte.GoFunc(Collect),
 	"known":   wdte.GoFunc(Known),
 	"sub":     wdte.GoFunc(Sub),
+	"reflect": wdte.GoFunc(Reflect),
 })
 
 // F returns a top-level frame that has S as its scope.

--- a/std/std.go
+++ b/std/std.go
@@ -580,7 +580,7 @@ func Reflect(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 		return wdte.Bool(r.Reflect(string(t)))
 	}
 
-	return reflect.TypeOf(v).Name() == t
+	return wdte.Bool(reflect.TypeOf(v).Name() == string(t))
 }
 
 // Scope is a scope containing the functions in this package.

--- a/std/stream/end.go
+++ b/std/stream/end.go
@@ -9,6 +9,10 @@ func (end) Call(wdte.Frame, ...wdte.Func) wdte.Func {
 	return end{}
 }
 
+func (end) Reflect(name string) bool { // nolint
+	return name == "End"
+}
+
 // End returns a special value that is returned by the next function
 // provided to new when it wants to end the stream.
 func End() wdte.Func {

--- a/std/stream/stream.go
+++ b/std/stream/stream.go
@@ -33,6 +33,10 @@ func (NextFunc) String() string { // nolint
 	return "<stream>"
 }
 
+func (NextFunc) Reflect(name string) bool { // nolint
+	return name == "Stream"
+}
+
 // Scope is a scope containing the functions in this package.
 var Scope = wdte.S().Map(map[wdte.ID]wdte.Func{
 	"new":    wdte.GoFunc(New),

--- a/types.go
+++ b/types.go
@@ -31,6 +31,17 @@ type Atter interface {
 	At(i Func) (Func, bool)
 }
 
+// A Reflector is a Func that can determine if it can be treated as
+// the named type or not. For example,
+//
+//    s := wdte.String("example")
+//    return s.Reflect("string")
+//
+// returns true.
+type Reflector interface {
+	Reflect(name string) bool
+}
+
 // A String is a string, as parsed from a string literal. That's about
 // it. Like everything else, it's a function. It simply returns itself
 // when called.
@@ -73,6 +84,10 @@ func (s String) At(i Func) (Func, bool) { // nolint
 	return nil, false
 }
 
+func (s String) Reflect(name string) { // nolint
+	return name == "String"
+}
+
 // A Number is a number, as parsed from a number literal. That's about
 // it. Like everything else, it's a function. It simply returns itself
 // when called.
@@ -99,6 +114,10 @@ func (n Number) String() string { // nolint
 	}
 
 	return bn.Text('g', 10)
+}
+
+func (n Number) Reflect(name string) bool { // nolint
+	return name == "Number"
 }
 
 // An Array represents a WDTE array type. It's similar to a Compound,
@@ -146,6 +165,10 @@ func (a Array) String() string { // nolint
 	return buf.String()
 }
 
+func (a Array) Reflect(name string) { // nolint
+	return name == "Array"
+}
+
 //func (a Array)Compare(other Func) (int, bool) {
 //	TODO: Implement this. I'm not sure if it should support ordering
 //	or not. I'm also not sure if it should call its elements in order
@@ -175,6 +198,10 @@ func (e Error) Error() string {
 	return fmt.Sprintf("WDTE Error: %v\n%s", e.Err, buf.Bytes())
 }
 
+func (e Error) Reflect(name string) { // nolint
+	return name == "Error"
+}
+
 // Bool is a boolean. Like other primitive types, it simply returns
 // itself when called.
 type Bool bool
@@ -188,4 +215,8 @@ func (b Bool) Compare(other Func) (int, bool) { // nolint
 		return 0, false
 	}
 	return -1, false
+}
+
+func (b Bool) Reflect(name string) { // nolint
+	return name == "Bool"
 }

--- a/types.go
+++ b/types.go
@@ -84,7 +84,7 @@ func (s String) At(i Func) (Func, bool) { // nolint
 	return nil, false
 }
 
-func (s String) Reflect(name string) { // nolint
+func (s String) Reflect(name string) bool { // nolint
 	return name == "String"
 }
 
@@ -165,7 +165,7 @@ func (a Array) String() string { // nolint
 	return buf.String()
 }
 
-func (a Array) Reflect(name string) { // nolint
+func (a Array) Reflect(name string) bool { // nolint
 	return name == "Array"
 }
 
@@ -198,7 +198,7 @@ func (e Error) Error() string {
 	return fmt.Sprintf("WDTE Error: %v\n%s", e.Err, buf.Bytes())
 }
 
-func (e Error) Reflect(name string) { // nolint
+func (e Error) Reflect(name string) bool { // nolint
 	return name == "Error"
 }
 
@@ -217,6 +217,6 @@ func (b Bool) Compare(other Func) (int, bool) { // nolint
 	return -1, false
 }
 
-func (b Bool) Reflect(name string) { // nolint
+func (b Bool) Reflect(name string) bool { // nolint
 	return name == "Bool"
 }

--- a/wdte.go
+++ b/wdte.go
@@ -372,6 +372,10 @@ func (s *Scope) String() string { // nolint
 	return buf.String()
 }
 
+func (s *Scope) Reflect(name string) { // nolint
+	return name == "Scope"
+}
+
 // A GoFunc is an implementation of Func that calls a Go function.
 // This is the easiest way to implement lower-level systems for WDTE
 // scripts to make use of.

--- a/wdte.go
+++ b/wdte.go
@@ -372,7 +372,7 @@ func (s *Scope) String() string { // nolint
 	return buf.String()
 }
 
-func (s *Scope) Reflect(name string) { // nolint
+func (s *Scope) Reflect(name string) bool { // nolint
 	return name == "Scope"
 }
 


### PR DESCRIPTION
Closes #136.

It works a bit differently than in #136. The initial implementation was pretty much as that issue gave as an example, but that quickly ran into a few issues. For one thing, `std/io/file`'s `File` type can act as a `Reader` and a `Writer`, as well as being itself a `File`. Simply returning a string identifier was not sufficient for handling all of these cases. Instead, it now works similarly to a Go type assertion, giving an assertion of functionality, rather than specifically checking the type the way an object oriented language would with a class hierarchy. For example,

```wdte
let example v => v {reflect 'Stream' => s.collect v};
```

works as a way to transparently convert streams into arrays and simply return all other types verbatim.

There's also a bit of a change to how `File` is implemented to allow it to determine if it is readable or writable. Unfortunately, this only works for files opened using the functions in `std/io/file`, since `os.File` doesn't seem to keep track of whether or not files are readable and/or writable.