### PR TITLE
wdte: Move `Reflect()` to Make it Easier for Go to Use Directly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/DeedleFake/wdte
 
 require (
 	github.com/peterh/liner v1.1.0
-	golang.org/x/crypto v0.0.0-20181025213731-e84da0312774
-	golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5 // indirect
+	golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16
+	golang.org/x/sys v0.0.0-20181030150119-7e31e0c00fa0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8Bz
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/peterh/liner v1.1.0 h1:f+aAedNJA6uk7+6rXsYBnhdo4Xux7ESLe+kcuVUF5os=
 github.com/peterh/liner v1.1.0/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
-golang.org/x/crypto v0.0.0-20181025213731-e84da0312774 h1:a4tQYYYuK9QdeO/+kEvNYyuR21S+7ve5EANok6hABhI=
-golang.org/x/crypto v0.0.0-20181025213731-e84da0312774/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5 h1:x6r4Jo0KNzOOzYd8lbcRsqjuqEASK6ob3auvWYM4/8U=
-golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16 h1:y6ce7gCWtnH+m3dCjzQ1PCuwl28DDIc3VNnvY29DlIA=
+golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/sys v0.0.0-20181030150119-7e31e0c00fa0 h1:biUuj9O+0+XckRUCDzjoOGm6yFV5c0IHbm1ODP3e4Zw=
+golang.org/x/sys v0.0.0-20181030150119-7e31e0c00fa0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/std/std.go
+++ b/std/std.go
@@ -3,7 +3,6 @@ package std
 import (
 	"fmt"
 	"math"
-	"reflect"
 
 	"github.com/DeedleFake/wdte"
 )
@@ -558,11 +557,8 @@ func Sub(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 //    reflect v type
 //    (reflect type) v
 //
-// It returns true if v can be considered to be of the given type. If
-// v implementes wdte.Reflector, v.Reflect() is used to check for
-// compatability. If not, a simple string comparison is done against
-// whatever Go's reflect package claims the short name of the type of
-// v to be.
+// It provides a simple wrapper around wdte.Reflect, checking
+// underlying type compatability.
 func Reflect(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	frame = frame.Sub("reflect")
 
@@ -575,11 +571,7 @@ func Reflect(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	v := args[0].Call(frame)
 	t := args[1].Call(frame).(wdte.String)
 
-	if r, ok := v.(wdte.Reflector); ok {
-		return wdte.Bool(r.Reflect(string(t)))
-	}
-
-	return wdte.Bool(reflect.TypeOf(v).Name() == string(t))
+	return wdte.Bool(wdte.Reflect(v, string(t)))
 }
 
 // Scope is a scope containing the functions in this package.

--- a/types.go
+++ b/types.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/big"
+	"reflect"
 	"strings"
 )
 
@@ -40,6 +41,19 @@ type Atter interface {
 // returns true.
 type Reflector interface {
 	Reflect(name string) bool
+}
+
+// Reflect checks if a Func can be considered to be of a given type.
+// If v implements Reflector, v.Reflect(name) is used to check for
+// compatability. If not, a simple string comparison is done against
+// whatever Go's reflect package claims the short name of the
+// underlying type to be.
+func Reflect(f Func, name string) bool {
+	if r, ok := f.(Reflector); ok {
+		return r.Reflect(name)
+	}
+
+	return reflect.TypeOf(f).Name() == name
 }
 
 // A String is a string, as parsed from a string literal. That's about


### PR DESCRIPTION
Closes #146.