### PR TITLE
wdte: use `t.Helper()` during testing

### DIFF
--- a/wdte_test.go
+++ b/wdte_test.go
@@ -33,9 +33,13 @@ type test struct {
 }
 
 func runTests(t *testing.T, tests []test) {
+	t.Helper()
+
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Helper()
+
 			if test.disabled {
 				t.SkipNow()
 			}


### PR DESCRIPTION
Thanks, https://github.com/golang/go/issues/28544#issuecomment-435401673. Had no idea that was there. Neat.