### PR TITLE
multiple: Add Macros

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -9,12 +9,12 @@ import (
 )
 
 // Parse parses a full script, returning the root node of the AST.
-func Parse(r io.Reader) (Node, error) {
-	return parse(r, tokenStack{pgen.NTerm("script")}, pgen.Table)
+func Parse(r io.Reader, macros scanner.MacroMap) (Node, error) {
+	return parse(r, tokenStack{pgen.NTerm("script")}, pgen.Table, macros)
 }
 
-func parse(r io.Reader, g tokenStack, table map[pgen.Lookup]pgen.Rule) (ast Node, err error) {
-	s := scanner.New(r)
+func parse(r io.Reader, g tokenStack, table map[pgen.Lookup]pgen.Rule, macros scanner.MacroMap) (ast Node, err error) {
+	s := scanner.New(r, macros)
 
 	more := s.Scan()
 	var cur *NTerm

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/DeedleFake/wdte
 require (
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/peterh/liner v1.1.0
-	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc
-	golang.org/x/sys v0.0.0-20190108104531-7fbe1cd0fcc2 // indirect
+	golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613
+	golang.org/x/sys v0.0.0-20190204203706-41f3e6584952 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,7 @@ github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/peterh/liner v1.1.0 h1:f+aAedNJA6uk7+6rXsYBnhdo4Xux7ESLe+kcuVUF5os=
 github.com/peterh/liner v1.1.0/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
-golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc h1:F5tKCVGp+MUAHhKp5MZtGqAlGX3+oCsiL1Q629FL90M=
-golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/sys v0.0.0-20190108104531-7fbe1cd0fcc2 h1:ku9Kvp2ZBWAz3GyvuUH3UV1bZCd7RxH0Qf1epWfIDKc=
-golang.org/x/sys v0.0.0-20190108104531-7fbe1cd0fcc2/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613 h1:MQ/ZZiDsUapFFiMS+vzwXkCTeEKaum+Do5rINYJDmxc=
+golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/sys v0.0.0-20190204203706-41f3e6584952 h1:FDfvYgoVsA7TTZSbgiqjAbfPbK47CNHdWl3h/PJtii0=
+golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -151,6 +151,15 @@ o => print "double\n" 'single\\';`,
 				{Type: scanner.EOF},
 			},
 		},
+		{
+			name: "Macro",
+			in:   `!fmt[{q}, 'greetings'];`,
+			out: []scanner.Token{
+				{Type: scanner.Macro, Val: [2]string{"fmt", "{q}, 'greetings'"}},
+				{Type: scanner.Keyword, Val: ";"},
+				{Type: scanner.EOF},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -153,7 +153,7 @@ o => print "double\n" 'single\\';`,
 		},
 		{
 			name: "Macro",
-			in:   `!fmt[{q}, 'greetings'];`,
+			in:   `@fmt[{q}, 'greetings'];`,
 			out: []scanner.Token{
 				{Type: scanner.Macro, Val: [2]string{"fmt", "{q}, 'greetings'"}},
 				{Type: scanner.Keyword, Val: ";"},
@@ -164,7 +164,7 @@ o => print "double\n" 'single\\';`,
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s := scanner.New(strings.NewReader(test.in))
+			s := scanner.New(strings.NewReader(test.in), nil)
 			for i := 0; s.Scan(); i++ {
 				if i >= len(test.out) {
 					t.Fatalf("Extra token: %#v", s.Tok())
@@ -203,7 +203,7 @@ var (
 )
 
 func ExampleScanner() {
-	s := scanner.New(r)
+	s := scanner.New(r, nil)
 	for s.Scan() {
 		/* Do something with s.Tok(). */
 	}

--- a/scanner/token.go
+++ b/scanner/token.go
@@ -20,6 +20,7 @@ const (
 	String
 	ID
 	Keyword
+	Macro
 	EOF
 )
 
@@ -35,6 +36,8 @@ func (t TokenType) String() string {
 		return "id"
 	case Keyword:
 		return "keyword"
+	case Macro:
+		return "macro"
 	case EOF:
 		return "EOF"
 	}

--- a/scanner/util.go
+++ b/scanner/util.go
@@ -57,3 +57,23 @@ func symbolicSuffix(str string) string {
 func isQuote(r rune) bool {
 	return (r == '\'') || (r == '"')
 }
+
+func endQuote(r rune) rune {
+	switch r {
+	case '(':
+		return ')'
+	case ')':
+		return '('
+	case '[':
+		return ']'
+	case ']':
+		return '['
+	case '{':
+		return '}'
+	case '}':
+		return '{'
+
+	default:
+		return r
+	}
+}

--- a/wdte.go
+++ b/wdte.go
@@ -9,13 +9,14 @@ import (
 	"strings"
 
 	"github.com/DeedleFake/wdte/ast"
+	"github.com/DeedleFake/wdte/scanner"
 )
 
 // Parse parses an AST from r and then translates it into a top-level
 // compound. im is used to handle import statements. If im is nil, a
 // no-op importer is used. In most cases, std.Import is a good default.
-func Parse(r io.Reader, im Importer) (Compound, error) {
-	root, err := ast.Parse(r)
+func Parse(r io.Reader, im Importer, macros scanner.MacroMap) (Compound, error) {
+	root, err := ast.Parse(r, macros)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Macros are handled at the scanner level in much the same way that is specified in #178. Unlike in there, however, the syntax uses `@` to specify a macro, rather than `!`. This is primarily to avoid ambiguity with the `!` function in the standard library, and also because `@` is the key used in Vim to replay a macro, although that's obviously a very different type of macro.