### PR TITLE
cmd/wdte: Add version info.

### DIFF
--- a/cmd/wdte/import.go
+++ b/cmd/wdte/import.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/DeedleFake/wdte"
@@ -36,6 +37,22 @@ func importer(wd string, blacklist []string, args []string, macros scanner.Macro
 
 	cliScope := wdte.S().Map(map[wdte.ID]wdte.Func{
 		"args": wargs,
+
+		"goVersion": wdte.GoFunc(func(frame wdte.Frame, args ...wdte.Func) wdte.Func {
+			return wdte.String(runtime.Version())
+		}),
+
+		"wdteVersion": wdte.GoFunc(func(frame wdte.Frame, args ...wdte.Func) wdte.Func {
+			v, err := wdteVersion()
+			if err != nil {
+				return &wdte.Error{
+					Frame: frame,
+					Err:   err,
+				}
+			}
+
+			return wdte.String(v)
+		}),
 	})
 
 	std.Register("cli", cliScope)

--- a/cmd/wdte/wdte.go
+++ b/cmd/wdte/wdte.go
@@ -1,15 +1,36 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
+	"runtime/debug"
 	"strings"
 )
+
+func wdteVersion() (string, error) {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", errors.New("Failed to read build info")
+	}
+
+	for _, dep := range bi.Deps {
+		if dep.Path != "github.com/DeedleFake/wdte" {
+			continue
+		}
+
+		return dep.Version, nil
+	}
+
+	return bi.Main.Version, nil
+}
 
 func main() {
 	blacklist := flag.String("blacklist", "", "Comma-separated list of modules that can't be imported.")
 	eval := flag.String("e", "", "An expression to evaluate instead of reading from a file.")
+	version := flag.Bool("version", false, "Print the Go and WDTE versions and then exit.")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %v [options] [<file> | -] [arguments...]\n\n", os.Args[0])
 
@@ -17,6 +38,19 @@ func main() {
 		flag.PrintDefaults()
 	}
 	flag.Parse()
+
+	if *version {
+		g := runtime.Version()
+		w, err := wdteVersion()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to get WDTE version: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Go: %v\n", g)
+		fmt.Printf("WDTE: %v\n", w)
+		return
+	}
 
 	im := importer("", strings.Split(*blacklist, ","), flag.Args(), nil)
 


### PR DESCRIPTION
This might not work quite right. It seems to keep returning `(devel)` for the WDTE version for some bizarre reason. Probably just need to build it using `go get` or something.