### PR TITLE
std: rename `sub` to `set` and genericize

### DIFF
--- a/wdte.go
+++ b/wdte.go
@@ -354,9 +354,16 @@ func (s *Scope) Call(frame Frame, args ...Func) Func { // nolint
 	return s
 }
 
-func (s *Scope) At(i Func) (Func, bool) { // nolint
+func (s *Scope) At(i Func) (Func, error) { // nolint
 	v := s.Get(ID(i.(String)))
-	return v, v != nil
+	if v == nil {
+		return nil, fmt.Errorf("%v is not in scope", i)
+	}
+	return v, nil
+}
+
+func (s *Scope) Set(k, v Func) (Func, error) { // nolint
+	return s.Add(ID(k.(String)), v), nil
 }
 
 func (s *Scope) String() string { // nolint
@@ -864,10 +871,10 @@ func AssignPattern(frame Frame, scope *Scope, ids []ID, val Func) (*Scope, Func)
 	}) (*Scope, Func) {
 		m := make(map[ID]Func, len(ids))
 		for i, id := range ids {
-			v, ok := f.At(Number(i))
-			if !ok {
+			v, err := f.At(Number(i))
+			if err != nil {
 				return nil, &Error{
-					Err:   errors.New("Atter shorter than pattern"),
+					Err:   err,
 					Frame: frame,
 				}
 			}

--- a/wdte_test.go
+++ b/wdte_test.go
@@ -443,6 +443,16 @@ func TestStd(t *testing.T) {
 			ret:    wdte.Number(math.Pi),
 		},
 		{
+			name:   "Set/Scope",
+			script: `let t => collect (let test => 3); let t => set t 'test2' 5; t.test2;`,
+			ret:    wdte.Number(5),
+		},
+		{
+			name:   "Set/Array",
+			script: `let t => [1; 2; 3]; set t 1 5;`,
+			ret:    wdte.Array{wdte.Number(1), wdte.Number(5), wdte.Number(3)},
+		},
+		{
 			name:   "Collect",
 			script: `let t => collect (let test => 3); t.test;`,
 			ret:    wdte.Number(3),
@@ -451,11 +461,6 @@ func TestStd(t *testing.T) {
 			name:   "Known",
 			script: `let t => collect (let test => 3; let other => 5); known t;`,
 			ret:    wdte.Array{wdte.String("other"), wdte.String("test")},
-		},
-		{
-			name:   "Sub",
-			script: `let t => collect (let test => 3); let t => sub t 'test2' 5; t.test2;`,
-			ret:    wdte.Number(5),
 		},
 		{
 			name:   "Reflect",


### PR DESCRIPTION
Also updates some built-in types to support the new system.

Hmmm... Maybe it should handle strings, too...