### PR TITLE
std/stream: Add `skip` and change `new`.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
 )
+
+go 1.13

--- a/std/stream/middle.go
+++ b/std/stream/middle.go
@@ -250,6 +250,43 @@ func Limit(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	})
 }
 
+// Skip is a WDTE function with the following signature:
+//
+//    (skip n) s
+//
+// Skip returns a Stream that skips the first n elements of s. In
+// other wotds, the first element of the returned stream will be
+// element n+1 of s.
+func Skip(frame wdte.Frame, args ...wdte.Func) wdte.Func {
+	frame = frame.Sub("skip")
+
+	if len(args) == 0 {
+		return wdte.GoFunc(Skip)
+	}
+
+	n := args[0].Call(frame).(wdte.Number)
+
+	return wdte.GoFunc(func(frame wdte.Frame, args ...wdte.Func) wdte.Func {
+		frame = frame.Sub("skip")
+
+		s := args[0].Call(frame).(Stream)
+
+		return NextFunc(func(frame wdte.Frame) (wdte.Func, bool) {
+			frame = frame.Sub("skip")
+
+			for n > 0 {
+				next, ok := s.Next(frame)
+				if !ok {
+					return next, ok
+				}
+				n--
+			}
+
+			return s.Next(frame)
+		})
+	})
+}
+
 // Zip is a WDTE function with the following signatures:
 //
 //    (zip s1) ...

--- a/std/stream/start.go
+++ b/std/stream/start.go
@@ -12,7 +12,9 @@ import (
 //
 // It returns a new Stream that calls next in order to get the next
 // element in the stream, passing it first initial and then the
-// previous value on each call. The Stream ends when next returns end.
+// previous value on each call. The Stream yields initial before it
+// begins yielding the values returned from next. The Stream ends when
+// next returns end.
 func New(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 	frame = frame.Sub("new")
 
@@ -28,12 +30,9 @@ func New(frame wdte.Frame, args ...wdte.Func) wdte.Func {
 			return nil, false
 		}
 
+		cur := prev
 		prev = next.Call(frame, prev)
-		if _, ok := prev.(end); ok {
-			return nil, false
-		}
-
-		return prev, true
+		return cur, true
 	})
 }
 

--- a/std/stream/stream.go
+++ b/std/stream/stream.go
@@ -49,6 +49,7 @@ var Scope = wdte.S().Map(map[wdte.ID]wdte.Func{
 	"enumerate": wdte.GoFunc(Enumerate),
 	"repeat":    wdte.GoFunc(Repeat),
 	"limit":     wdte.GoFunc(Limit),
+	"skip":      wdte.GoFunc(Skip),
 	"zip":       wdte.GoFunc(Zip),
 
 	"end":     End(),

--- a/types.go
+++ b/types.go
@@ -227,6 +227,10 @@ func (e Error) Error() string {
 	return e.Err.Error()
 }
 
+func (e Error) Unwrap() error {
+	return e.Err
+}
+
 func (e Error) Reflect(name string) bool { // nolint
 	return name == "Error"
 }

--- a/wdte_test.go
+++ b/wdte_test.go
@@ -579,6 +579,11 @@ func TestStream(t *testing.T) {
 			},
 		},
 		{
+			name:   "Skip",
+			script: `let s => import 'stream'; s.range 3 -> s.skip 2 -> s.collect;`,
+			ret:    wdte.Array{wdte.Number(2)},
+		},
+		{
 			name:   "Zip",
 			script: `let s => import 'stream'; s.zip (s.range 2) (s.range 1 2) -> s.collect;`,
 			ret: wdte.Array{

--- a/wdte_test.go
+++ b/wdte_test.go
@@ -515,7 +515,7 @@ func TestStream(t *testing.T) {
 		{
 			name:   "New",
 			script: `let s => import 'stream'; s.new 0 (@ f n => + n 1 {> 5 => s.end}) -> s.collect;`,
-			ret:    wdte.Array{wdte.Number(1), wdte.Number(2), wdte.Number(3), wdte.Number(4), wdte.Number(5)},
+			ret:    wdte.Array{wdte.Number(0), wdte.Number(1), wdte.Number(2), wdte.Number(3), wdte.Number(4), wdte.Number(5)},
 		},
 		{
 			name:   "Range/1",


### PR DESCRIPTION
The old behavior of not returning the initial value from the stream can be replicated by just using `new ... -> skip 1`.